### PR TITLE
Fix: Add month handling in date picker element (#6)

### DIFF
--- a/app/src/main/java/com/codewithdipesh/habitized/presentation/homescreen/component/WeekDayComponent.kt
+++ b/app/src/main/java/com/codewithdipesh/habitized/presentation/homescreen/component/WeekDayComponent.kt
@@ -70,6 +70,9 @@ fun WeekDayComponent(
                     fontSize = 22.sp
                 )
             )
+            Text(
+                text = day.date.month.getDisplayName(java.time.format.TextStyle.SHORT,Locale.getDefault()),
+            )
         }
     }
 }


### PR DESCRIPTION
This PR adds the functionality to display the months in the date picker on the home screen for improved user experience.

### Changes Made
- Modified the date picker logic to include the month display.
- Updated UI elements to show the month name clearly with the date.
- Verified the feature in the emulator for correctness.

### How to Test
1. Navigate to the home screen.
2. Confirm that the month is displayed correctly in the date picker.

### Proof of Fix
![github_video-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/456f2348-3b31-4c81-9121-8c95ed89c036)

### Related Issue
Fixes #6
