### PR TITLE
Fix: Add month handling in Home screen date picker (#6)

### DIFF
--- a/app/src/main/java/com/codewithdipesh/habitized/presentation/homescreen/component/WeekDayComponent.kt
+++ b/app/src/main/java/com/codewithdipesh/habitized/presentation/homescreen/component/WeekDayComponent.kt
@@ -70,6 +70,16 @@ fun WeekDayComponent(
                     fontSize = 22.sp
                 )
             )
+            Text(
+                text = day.date.month.getDisplayName(java.time.format.TextStyle.SHORT,Locale.getDefault()),
+                style = TextStyle(
+                    color = if(selected) MaterialTheme.colorScheme.outlineVariant
+                    else MaterialTheme.colorScheme.onPrimary,
+                    fontFamily = playfair,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 11.sp
+                )
+            )
         }
     }
 }


### PR DESCRIPTION
### Summary
- Implemented month display in the Home screen date picker.
- Applied consistent text styling (color and font) matching the date style.
- Adjusted text size to 11.sp for better UI aesthetics.
- Squashed previous unnecessary commits into one clean commit.

### How to Test
1. Open the Home screen.
2. Launch the date picker.
3. Verify that the month is displayed as per design.
4. Ensure text color, font, and size (11.sp) match app aesthetics.

![WhatsApp Image 2025-07-18 at 11 58 50 PM](https://github.com/user-attachments/assets/d56f5000-8f4e-41d9-951e-7c8e241c9ea0)

### Notes
This PR addresses issues 
#6 and #14.
