### PR TITLE
enhancement: Show month in home screen date picker

### DIFF
--- a/app/src/main/java/com/codewithdipesh/habitized/presentation/homescreen/component/WeekDayComponent.kt
+++ b/app/src/main/java/com/codewithdipesh/habitized/presentation/homescreen/component/WeekDayComponent.kt
@@ -70,6 +70,16 @@ fun WeekDayComponent(
                     fontSize = 22.sp
                 )
             )
+            Text(
+                text = day.date.month.getDisplayName(java.time.format.TextStyle.SHORT,Locale.getDefault()),
+                style = TextStyle(
+                    color = if(selected) MaterialTheme.colorScheme.outlineVariant
+                    else MaterialTheme.colorScheme.onPrimary,
+                    fontFamily = playfair,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 11.sp
+                )
+            )
         }
     }
 }


### PR DESCRIPTION
## Issue
When selecting a date on the home screen, the month was not clearly visible, which could confuse the user.

## Changes Made
- Modified the date picker logic to ensure that the selected month is also displayed clearly on the home screen.
- Improved date formatting to include the month.

## How to Test
1. Open the app and navigate to the home screen.
2. Click on the date picker.
3. Select any date.
4. Verify that both the date and month are visible on the home screen.

## Proof (Screenshot)
![WhatsApp Image 2025-07-18 at 11 58 50 PM](https://github.com/user-attachments/assets/08e2145d-c1d1-4448-9703-46c0f3de3049)


## Notes
- This commit includes all related changes combined into a single commit with the `enhancement:` prefix.
