### PR TITLE
fix: Focus and show keyboard when creating a new todo

### DIFF
--- a/app/src/main/java/com/codewithdipesh/habitized/presentation/homescreen/component/SubTaskEditor.kt
+++ b/app/src/main/java/com/codewithdipesh/habitized/presentation/homescreen/component/SubTaskEditor.kt
@@ -21,10 +21,16 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -169,7 +175,8 @@ fun TodoEditor(
     onToggle : () -> Unit= {},
     onDelete : (UUID) -> Unit = {}
 ) {
-
+    val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
     Row(
         modifier =  modifier.fillMaxWidth()
             .padding(start = 8.dp),
@@ -225,8 +232,15 @@ fun TodoEditor(
                     singleLine = false,
                     maxLines = 3,
                     cursorBrush = SolidColor(colorResource(R.color.primary)),
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth().focusRequester(focusRequester).onFocusChanged{
+                        if (it.isFocused) {
+                            keyboardController?.show()
+                        }
+                    }
                 )
+                LaunchedEffect(Unit) {
+                    focusRequester.requestFocus()  // This will request focus when the Composable is first displayed
+                }
                 // Placeholder shown only when title is empty
                 if (todo.title.isEmpty()) {
                     Text(


### PR DESCRIPTION
## Issue
When creating a new todo, the input field was not automatically focused, and the keyboard did not appear. This required the user to manually tap the field before typing.  
This issue was reported in **#18**.

---

## Changes Made
- Implemented `FocusRequester` and `LocalSoftwareKeyboardController` to manage focus and keyboard visibility.
- Added `focusRequester.requestFocus()` inside a `LaunchedEffect` to ensure the new todo input is automatically focused when created.
- Ensured the soft keyboard is displayed immediately for smooth user experience.

---

## How to Test
1. Open the app and navigate to the **Todo List** screen.
2. Tap the **Add Todo** button.
3. Verify:
   - The new todo input is automatically focused.
   - The keyboard appears immediately, allowing the user to start typing without extra taps.

---

## Media
[Video Proof](https://github.com/user-attachments/assets/21fa8cb8-7c05-4888-bac1-44afb1ed2fc7)

---

## Additional Notes
- **Fixes #18.**
